### PR TITLE
Update mlforecast:

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,4 @@
+#upload_channels:
+#  - sfe1ed40
+channels:
+  - sfe1ed40

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,4 +1,4 @@
 #upload_channels:
 #  - sfe1ed40
-channels:
-  - sfe1ed40
+#channels:
+#  - sfe1ed40

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "mlforecast" %}
-{% set version = "0.7.0" %}
+{% set version = "0.7.2" %}
 
 
 package:
@@ -8,11 +8,11 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/mlforecast-{{ version }}.tar.gz
-  sha256: 07c48e7b113df14c634d2cc91c070cda36f04323f5889070cb36fcd4e6188223
+  sha256: dd06a073ab9f81a72f51cc441d204485bbe87518ae8c3afe7a302bc03adccd21
 
 build:
   number: 0
-  skip: true  # [py>=310 or s390x]
+  skip: true  # [py<36 or s390x]
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
 
 requirements:
@@ -30,11 +30,9 @@ requirements:
 
 test:
   imports:
-    - mlforecast
-  
+    - mlforecast 
   requires:
     - pip
-
   commands:
     - pip check
 


### PR DESCRIPTION
 - version increased and sha256 updated.
 - remove skipping for py>=310.
 - abs.yaml added as this package goes to Snowflake channel.