### PR TITLE
Update to 0.10.0 ❄️

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,4 +1,2 @@
-#upload_channels:
-#  - sfe1ed40
-#channels:
-#  - sfe1ed40
+upload_channels:
+ - sfe1ed40

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "mlforecast" %}
-{% set version = "0.7.2" %}
+{% set version = "0.10.0" %}
 
 
 package:
@@ -8,11 +8,11 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/mlforecast-{{ version }}.tar.gz
-  sha256: dd06a073ab9f81a72f51cc441d204485bbe87518ae8c3afe7a302bc03adccd21
+  sha256: c65acff268b62f49bc2826a93fc4bc8615f2569c7ba35d02354cc79b7ea313f4
 
 build:
   number: 0
-  skip: true  # [py<36 or s390x]
+  skip: true  # [py<37 or s390x]
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
 
 requirements:
@@ -22,10 +22,11 @@ requirements:
     - wheel
     - setuptools
   run:
+    - python
     - numba
     - pandas
-    - python
     - scikit-learn
+    - utilsforecast >=0.0.6
     - window-ops
 
 test:


### PR DESCRIPTION
mlforecast 0.10.0 ❄️

**Destination channel:** Snowflake

### Links

- [PKG-3686](https://anaconda.atlassian.net/browse/PKG-3686)
- [Upstream repository](https://github.com/Nixtla/mlforecast/compare/v0.7.3..v0.10.0)

### Explanation of changes:

Note that we are not updating to the latest because `autogluon` specifically wants `>=0.10.0,<0.10.1`. I tried to relax that range a bit but it really needs 0.10.0 as far as I see.


[PKG-3686]: https://anaconda.atlassian.net/browse/PKG-3686?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ